### PR TITLE
Fix problem with inkscape command line with handling spaces

### DIFF
--- a/svg-objects-export.py
+++ b/svg-objects-export.py
@@ -176,7 +176,7 @@ def exportObject(obj,args,prefix,extension,infile):
 			export = confirm(prompt='File %s already exists, do you want to overwrite it?' % (destfile))				
 	if export:				
 		message('  '+obj+' to '+destfile)
-		command = args.inkscape+' -i '+obj+' --export-'+args.type+' '+destfile+' '+args.extra+' '+infile
+		command = args.inkscape+' -i "'+obj+'" --export-'+args.type+' "'+destfile+'" '+args.extra+' '+infile
 		debug("runnning "+command)
 		run(command, shell=True)
 


### PR DESCRIPTION
Hi @berteh,
I found that spaces in Layer IDs or/and destfile caused the script to crash.
Adding double quotes around these two strings solved the problem, so I'd like to propose this improvement.
Best, A: 